### PR TITLE
Potential fix for code scanning alert no. 325: Uncontrolled command line

### DIFF
--- a/modules/update.py
+++ b/modules/update.py
@@ -5,6 +5,7 @@ import sys
 import re
 import signal
 import subprocess
+import shlex
 from aiogram import F, Dispatcher, types, Bot
 from aiogram.types import KeyboardButton, InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.exceptions import TelegramBadRequest
@@ -43,10 +44,29 @@ def validate_branch_name(branch: str) -> str:
         raise ValueError(f"Security Alert: Invalid branch name: '{branch}'")
     return branch
 
-async def run_command(cmd: str):
+async def run_command(cmd):
+    """
+    Run a command asynchronously without invoking a shell.
+
+    `cmd` can be either:
+      - a list/tuple of arguments: ['git', 'fetch', 'origin']
+      - a string, which will be split into args with shlex.split
+    """
     try:
-        proc = await asyncio.create_subprocess_shell(
-            cmd,
+        if isinstance(cmd, (str, bytes)):
+            # Safely split string into arguments; no shell is used.
+            if isinstance(cmd, bytes):
+                cmd = cmd.decode()
+            args = shlex.split(cmd)
+        else:
+            args = list(cmd)
+
+        if not args:
+            return -1, "", "Empty command"
+
+        proc = await asyncio.create_subprocess_exec(
+            args[0],
+            *args[1:],
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
@@ -58,7 +78,7 @@ async def run_command(cmd: str):
 # --- GIT HELPERS ---
 
 async def get_current_branch():
-    code, out, err = await run_command("git rev-parse --abbrev-ref HEAD")
+    code, out, err = await run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"])
     if code == 0 and out:
         return out.strip()
     return "main"
@@ -124,7 +144,7 @@ async def get_update_info():
         branch = await get_current_branch()
         branch = validate_branch_name(branch)
 
-        fetch_code, _, _ = await run_command("git fetch origin")
+        fetch_code, _, _ = await run_command(["git", "fetch", "origin"])
         if fetch_code != 0:
             return get_version_from_file(), "Error", branch, False
 
@@ -140,7 +160,7 @@ async def get_update_info():
         
         if update_available:
             # Пытаемся вытащить номер версии из удаленного файла для красоты
-            code, out, err = await run_command(f"git show origin/{branch}:CHANGELOG.md")
+            code, out, err = await run_command(["git", "show", f"origin/{branch}:CHANGELOG.md"])
             if code == 0:
                 match = re.search(r"## \[(\d+\.\d+\.\d+)\]", out)
                 remote_ver_display = match.group(1) if match else remote_hash[:7]
@@ -160,15 +180,15 @@ async def execute_bot_update(branch: str, restart_source: str = "unknown"):
         branch = validate_branch_name(branch)
         logging.info(f"Starting bot update on branch '{branch}'...")
         
-        code, _, err = await run_command("git fetch origin")
+        code, _, err = await run_command(["git", "fetch", "origin"])
         if code != 0:
             raise Exception(f"Git fetch failed: {err}")
         
-        code, _, err = await run_command(f"git reset --hard origin/{branch}")
+        code, _, err = await run_command(["git", "reset", "--hard", f"origin/{branch}"])
         if code != 0:
             raise Exception(f"Git reset failed: {err}")
 
-        pip_cmd = f"{sys.executable} -m pip install -r requirements.txt"
+        pip_cmd = [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
         code, _, err = await run_command(pip_cmd)
         if code != 0:
             logging.warning(f"Pip install warning: {err}")


### PR DESCRIPTION
Potential fix for [https://github.com/jatixs/tgbotvpscp/security/code-scanning/325](https://github.com/jatixs/tgbotvpscp/security/code-scanning/325)

In general, to fix uncontrolled command line issues, avoid passing user-influenced strings to shell-using APIs (such as `create_subprocess_shell` or `subprocess.call(..., shell=True)`). Instead, use argument-vector APIs (`create_subprocess_exec`, `subprocess.run` with a list) so each argument is passed directly to the executable without shell parsing. If dynamic user values must be included, validate them strictly (as is already done with `validate_branch_name`) and pass them as separate arguments rather than interpolating them into a single shell command.

For this code, the best fix without changing visible functionality is:

1. Replace `run_command` so that:
   - It uses `asyncio.create_subprocess_exec` instead of `create_subprocess_shell`.
   - It accepts the command either as a list of arguments, or as a string that is safely split into arguments using `shlex.split`. This preserves flexibility while avoiding the shell.
2. Update all internal callers in this file to pass argument lists instead of interpolated strings where possible:
   - `get_current_branch`: change `"git rev-parse --abbrev-ref HEAD"` to `["git", "rev-parse", "--abbrev-ref", "HEAD"]`.
   - `get_update_info`: change `"git fetch origin"` to `["git", "fetch", "origin"]` and `f"git show origin/{branch}:CHANGELOG.md"` to `["git", "show", f"origin/{branch}:CHANGELOG.md"]`. `branch` is still validated via `validate_branch_name`.
   - `execute_bot_update`: change `"git fetch origin"` to `["git", "fetch", "origin"]`, `f"git reset --hard origin/{branch}"` to `["git", "reset", "--hard", f"origin/{branch}"]`, and the `pip_cmd` string to an argument list `[sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]`.
3. Add an `import shlex` to support optional splitting of string commands inside `run_command`.

All changes are confined to `modules/update.py` in regions shown, and no new third-party dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
